### PR TITLE
Add format_glossary unit tests

### DIFF
--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -1,4 +1,8 @@
 import unittest
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from trial_integrated4 import format_glossary
 
 class TestExample(unittest.TestCase):
 
@@ -6,18 +10,18 @@ class TestExample(unittest.TestCase):
         """A simple placeholder test that always passes."""
         self.assertEqual(True, True)
 
-    # Future tests for utilities from trial_integrated4.py would go here.
-    # For example, if we could isolate a function like 'format_glossary':
-    #
-    # def test_format_glossary_empty(self):
-    #     from trial_integrated4 import format_glossary # Assuming we could import
-    #     self.assertEqual(format_glossary([]), "")
-    #
-    # def test_format_glossary_single_item(self):
-    #     from trial_integrated4 import format_glossary
-    #     item = [{"source": "term", "target": " Begriff", "notes": "example"}]
-    #     expected = "<GlossaryItem><Source>term</Source><Target> Begriff</Target><Notes>example</Notes></GlossaryItem>"
-    #     self.assertEqual(format_glossary(item), expected)
+    def test_format_glossary_empty(self):
+        """format_glossary should return an empty string for an empty list."""
+        self.assertEqual(format_glossary([]), "")
+
+    def test_format_glossary_single_item(self):
+        """format_glossary should correctly format a single glossary item."""
+        item = [{"source": "term", "target": "Begriff", "notes": "example"}]
+        expected = (
+            "<GlossaryItem><Source>term</Source><Target>Begriff</Target>"
+            "<Notes>example</Notes></GlossaryItem>"
+        )
+        self.assertEqual(format_glossary(item), expected)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- import `format_glossary` from `trial_integrated4`
- test empty and single item glossary cases with `unittest`
- ensure tests can locate repo root

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841f33aa7ac832ea117da002405ef28